### PR TITLE
update container base image to run smokescreen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 RUN go build .
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 COPY --from=builder /go/src/app/smokescreen /usr/local/bin/smokescreen
 COPY acl.yaml /etc/smokescreen/acl.yaml


### PR DESCRIPTION
running on ubuntu 18.04 as is fails with Go erroring due to missing GLIBC_2.32 and GLIBC_2.34

Updating prod base image to ubuntu:22.04 solves the issue and runs smokescreen fine